### PR TITLE
Feature/mk fixes

### DIFF
--- a/apps/processing/midibox_cv_v2/README.txt
+++ b/apps/processing/midibox_cv_v2/README.txt
@@ -2,13 +2,13 @@ $Id$
 
 MIDIbox CV V2
 ===============================================================================
-Copyright (C) 2020 Thorsten Klose (tk@midibox.org)
+Copyright (C) 2021 Thorsten Klose (tk@midibox.org)
 Licensed for personal non-commercial use only.
 All other rights reserved.
 ===============================================================================
 
 Required tools:
-  -> http://www.ucapps.de/mio32_c.html
+  -> http://www.ucapps.de/mios32_c.html
 
 ===============================================================================
 
@@ -26,7 +26,6 @@ Optional hardware:
 
 The MIDIbox CV project is introduced at this webpage:
 http://ucapps.de/midibox_cv_v2.html
-
 
 Please read also CHANGELOG.txt for the last changes.
 

--- a/apps/processing/midibox_cv_v2/README.txt
+++ b/apps/processing/midibox_cv_v2/README.txt
@@ -2,7 +2,7 @@ $Id$
 
 MIDIbox CV V2
 ===============================================================================
-Copyright (C) 2011 Thorsten Klose (tk@midibox.org)
+Copyright (C) 2020 Thorsten Klose (tk@midibox.org)
 Licensed for personal non-commercial use only.
 All other rights reserved.
 ===============================================================================
@@ -13,18 +13,19 @@ Required tools:
 ===============================================================================
 
 Required hardware:
-   o MBHP_CORE_STM32 or MBHP_CORE_LPC17
+   o MBHP_CORE_STM32, or MBHP_CORE_LPC17, or MBHP_CORE_STM32F4
    o a MBHP_AOUT, MBHP_AOUT_LC or MBHP_AOUT_NG module
    o up to 4 MBHP_OUTX4 modules
    o a SD Card to store the customized setup (and to load MIDI files)
 
 Optional hardware:
-   o a 2x20 LCD for configuration + 6 buttons + 1 rotary encoder
+   o a 2x20 LCD for configuration + 6 buttons + 1 rotary encoder, configured
+   as an SCS
 
 ===============================================================================
 
 The MIDIbox CV project is introduced at this webpage:
-http://www.ucapps.de/midibox_cv.html
+http://ucapps.de/midibox_cv_v2.html
 
 
 Please read also CHANGELOG.txt for the last changes.

--- a/apps/processing/midibox_cv_v2/hwcfg/latigidon/MBCV_HW.CV2
+++ b/apps/processing/midibox_cv_v2/hwcfg/latigidon/MBCV_HW.CV2
@@ -5,17 +5,9 @@
 
 
 ##################################################
-# AOUT interface
-# Following interfaces are supported:
-#   o none
-#   o AOUT
-#   o AOUT_LC
-#   o AOUT_NG
-#   o MCP_Gx1
-#   o MCP_Gx2
-##################################################
+# AOUT interface now configured in app itself
 
-AOUT_IF AOUT_NG
+##################################################
 
 
 ##################################################

--- a/apps/processing/midibox_cv_v2/hwcfg/standard/MBCV_HW.CV2
+++ b/apps/processing/midibox_cv_v2/hwcfg/standard/MBCV_HW.CV2
@@ -5,17 +5,9 @@
 
 
 ##################################################
-# AOUT interface
-# Following interfaces are supported:
-#   o none
-#   o AOUT
-#   o AOUT_LC
-#   o AOUT_NG
-#   o MCP_Gx1
-#   o MCP_Gx2
-##################################################
+# AOUT interface now configured in app itself
 
-AOUT_IF AOUT_NG
+##################################################
 
 
 ##################################################

--- a/apps/processing/midibox_cv_v2/src/components/MbCv.cpp
+++ b/apps/processing/midibox_cv_v2/src/components/MbCv.cpp
@@ -595,7 +595,7 @@ CREATE_GROUP(Env2, "ENV2");
 CREATE_ACCESS_FUNCTIONS(Env2, Amplitude,               "Amplitude",       *value = (int)cv->mbCvEnv2[arg].envAmplitude + 0x80,          cv->mbCvEnv2[arg].envAmplitude = (int)value - 0x80);
 CREATE_ACCESS_FUNCTIONS(Env2, CurvePos,                "CurvePos",        *value = (int)cv->mbCvEnv2[arg].envCurvePos,                  cv->mbCvEnv2[arg].envCurvePos = (int)value);
 CREATE_ACCESS_FUNCTIONS(Env2, CurveNeg,                "CurveNeg",        *value = (int)cv->mbCvEnv2[arg].envCurveNeg,                  cv->mbCvEnv2[arg].envCurveNeg = (int)value);
-CREATE_ACCESS_FUNCTIONS(Env2, Offset,                  "Offset",          *value = (int)cv->mbCvEnv2[arg].envOffset,                    cv->mbCvEnv2[arg].envOffset = (int)value);
+CREATE_ACCESS_FUNCTIONS(Env2, Offset,                  "Offset",          *value = (int)cv->mbCvEnv2[arg].envOffset + 0x80,             cv->mbCvEnv2[arg].envOffset = (int)value - 0x80);
 CREATE_ACCESS_FUNCTIONS(Env2, Rate,                    "Rate",            *value = (int)cv->mbCvEnv2[arg].envRate,                      cv->mbCvEnv2[arg].envRate = (int)value);
 CREATE_ACCESS_FUNCTIONS(Env2, LoopAttack,              "Loop Attack",     *value = (int)cv->mbCvEnv2[arg].envLoopAttack,                cv->mbCvEnv2[arg].envLoopAttack = (int)value);
 CREATE_ACCESS_FUNCTIONS(Env2, SustainStep,             "Sustain Step",    *value = (int)cv->mbCvEnv2[arg].envSustainStep,               cv->mbCvEnv2[arg].envSustainStep = (int)value);

--- a/apps/processing/midibox_cv_v2/src/components/MbCv.cpp
+++ b/apps/processing/midibox_cv_v2/src/components/MbCv.cpp
@@ -152,7 +152,7 @@ bool MbCv::tick(const u8 &updateSpeedFactor)
                 mod += (lfo1Value * (s32)mbCvLfo[0].lfoDepthPitch) / 128;
                 mod += (lfo2Value * (s32)mbCvLfo[1].lfoDepthPitch) / 128;
                 mod += (env1Value * (s32)mbCvEnv1[0].envDepthPitch) / 128;
-                mod += (env1Value * (s32)mbCvEnv2[0].envDepthPitch) / 128;
+                mod += (env2Value * (s32)mbCvEnv2[0].envDepthPitch) / 128;
                 mbCvMod.modDst[MBCV_MOD_DST_CV] = mod;
             }
 


### PR DESCRIPTION
These are things I have fixed in MBCV2 recently.

- ENV2 was showing incorrect offset in Lemur
- ENV2 was not possible to send to CV
- the HW config files still included the AOUT, but we now specify that in the app itself
- while here I thought I'd tweak the README a bit!

This has all been tested by compiling on macOS and running on STM324F core. Lemur was on iPad.