### PR TITLE
Update seq_ui_trkrnd.c

### DIFF
--- a/apps/sequencers/midibox_seq_v4/core/seq_ui_trkrnd.c
+++ b/apps/sequencers/midibox_seq_v4/core/seq_ui_trkrnd.c
@@ -507,7 +507,7 @@ static s32 RandomGenerator(u32 req)
 	  if( !range || range > 128 ) // (on underrun...)
 	    range = 1;
 	} else {
-	  base = 0x40;
+	  base = 0x3c;//<-randomization start point
 	  range = par_layer_range[layer];
 	}
 


### PR DESCRIPTION
line 510  base = 0x40 this way randomization starts at E-3 ,instead why not start at root which is 3c C-3